### PR TITLE
SecurityConfig 전체 permitAll 임시 적용 (테스트 용도)

### DIFF
--- a/src/main/java/com/codeit/sb01otbooteam06/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/config/SecurityConfig.java
@@ -5,10 +5,13 @@ import com.codeit.sb01otbooteam06.domain.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -18,28 +21,17 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
-    public SecurityFilterChain filterChain(org.springframework.security.config.annotation.web.builders.HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         return http
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .authorizeHttpRequests(auth -> auth
-                        // 인증 없이 허용할 경로들
-                        .requestMatchers(
-                                "/api/auth/**",
-                                "/api/users",       // 회원가입 POST 허용
-                                "/swagger-ui/**",
-                                "/swagger-custom-ui.html",
-                                "/v3/**"
-                        ).permitAll()
-                        .anyRequest().authenticated() // 나머지 요청은 인증 필요
+                        .anyRequest().permitAll()  // 전체 열어둠
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
-                        org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
-
     /**
      * 비밀번호 암호화를 위한 PasswordEncoder 빈 등록
      */

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/AuthController.java
@@ -4,12 +4,17 @@ import com.codeit.sb01otbooteam06.domain.auth.dto.ResetPasswordRequest;
 import com.codeit.sb01otbooteam06.domain.auth.dto.SignInRequest;
 import com.codeit.sb01otbooteam06.domain.auth.dto.TokenResponse;
 import com.codeit.sb01otbooteam06.domain.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 /**
  * 인증 관련 API 컨트롤러 (Swagger 명세 기준 완성본)
@@ -23,37 +28,82 @@ public class AuthController {
 
     /**
      * 로그인 - accessToken 반환, refreshToken 쿠키에 저장
+     * 성공: 200 OK, accessToken 문자열 반환
+     * 실패: 401 Unauthorized, 예외 JSON 반환
      */
     @PostMapping("/sign-in")
-    public ResponseEntity<String> signIn(@RequestBody @Valid SignInRequest request,
-                                         HttpServletResponse response) {
-        TokenResponse tokenResponse = authService.signIn(request);
+    public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request,
+                                    HttpServletResponse response) {
 
-        ResponseCookie cookie = ResponseCookie.from("refresh_token", tokenResponse.getRefreshToken())
-                .httpOnly(true)
-                .secure(false) // 배포 시 true로 변경 필요
-                .path("/")
-                .maxAge(7 * 24 * 60 * 60) // 7일
-                .build();
+        try {
+            TokenResponse tokenResponse = authService.signIn(request);
 
-        response.addHeader("Set-Cookie", cookie.toString());
-        return ResponseEntity.ok(tokenResponse.getAccessToken());
+            ResponseCookie cookie = ResponseCookie.from("refresh_token", tokenResponse.getRefreshToken())
+                    .httpOnly(true)
+                    .secure(false) // 배포 시 true로 변경 필요
+                    .path("/")
+                    .maxAge(7 * 24 * 60 * 60) // 7일
+                    .build();
+
+            response.addHeader("Set-Cookie", cookie.toString());
+            return ResponseEntity.ok(tokenResponse.getAccessToken());
+
+        } catch (IllegalArgumentException e) {
+            // 비밀번호 불일치 등 실패 케이스
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "SignInFailedException",
+                    "message", e.getMessage(),
+                    "details", Map.of()
+            ));
+        } catch (Exception e) {
+            // 기타 예외 처리
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "SignInFailedException",
+                    "message", "로그인에 실패했습니다.",
+                    "details", Map.of()
+            ));
+        }
     }
 
     /**
      * 비밀번호 초기화 (임시 비밀번호 발급)
+     * 성공: 204 No Content
+     * 실패: 404 Not Found, 예외 JSON 반환
      */
     @PostMapping("/reset-password")
-    public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
-        authService.resetPassword(request);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
+
+        try {
+            authService.resetPassword(request);
+            return ResponseEntity.noContent().build();
+
+        } catch (com.codeit.sb01otbooteam06.domain.user.exception.UserNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
+                    "exceptionName", "UserNotFoundException",
+                    "message", e.getMessage(),
+                    "details", Map.of()
+            ));
+        }
     }
 
     /**
      * 로그아웃 - refreshToken 쿠키 제거
+     * 성공: 204 No Content
+     * 실패: 401 Unauthorized, 예외 JSON 반환
      */
     @PostMapping("/sign-out")
-    public ResponseEntity<Void> signOut(HttpServletResponse response) {
+    public ResponseEntity<?> signOut(@CookieValue(value = "refresh_token", required = false) String refreshToken,
+                                     HttpServletResponse response) {
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "RefreshTokenMissingException",
+                    "message", "로그인 정보가 없습니다.",
+                    "details", Map.of()
+            ));
+        }
+
+        // 쿠키 제거
         ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
                 .secure(false)
@@ -65,21 +115,85 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+
     /**
      * 토큰 재발급 - refreshToken으로 새로운 accessToken 발급
+     * 성공: 200 OK, accessToken 반환
+     * 실패: 401 Unauthorized, 예외 JSON 반환
      */
     @PostMapping("/refresh")
-    public ResponseEntity<String> refreshToken(@CookieValue("refresh_token") String refreshToken) {
-        String newAccessToken = authService.refreshAccessToken(refreshToken);
-        return ResponseEntity.ok(newAccessToken);
+    public ResponseEntity<?> refreshToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "RefreshTokenMissingException",
+                    "message", "리프레시 토큰이 없습니다.",
+                    "details", Map.of()
+            ));
+        }
+
+        try {
+            String newAccessToken = authService.refreshAccessToken(refreshToken);
+            return ResponseEntity.ok(newAccessToken);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "InvalidRefreshTokenException",
+                    "message", e.getMessage(),
+                    "details", Map.of()
+            ));
+        }
     }
 
     /**
      * 엑세스 토큰 조회 - refreshToken으로 accessToken 반환
+     * 성공: 200 OK, accessToken 반환
+     * 실패: 401 Unauthorized, 예외 JSON 반환
      */
     @GetMapping("/me")
-    public ResponseEntity<String> getAccessToken(@CookieValue("refresh_token") String refreshToken) {
-        String accessToken = authService.getAccessToken(refreshToken);
-        return ResponseEntity.ok(accessToken);
+    public ResponseEntity<?> getAccessToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
+
+        if (refreshToken == null || refreshToken.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "RefreshTokenMissingException",
+                    "message", "리프레시 토큰이 없습니다.",
+                    "details", Map.of()
+            ));
+        }
+
+        try {
+            String accessToken = authService.getAccessToken(refreshToken);
+            return ResponseEntity.ok(accessToken);
+
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "InvalidRefreshTokenException",
+                    "message", e.getMessage(),
+                    "details", Map.of()
+            ));
+        }
+    }
+    /**
+     * CSRF 토큰 조회 API
+     * 성공: 200 OK, 토큰 정보 JSON 반환
+     * 실패: 401 Unauthorized, 예외 JSON 반환
+     */
+    @GetMapping("/csrf-token")
+    public ResponseEntity<?> getCsrfToken(HttpServletRequest request) {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+
+        if (csrfToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
+                    "exceptionName", "CsrfTokenMissingException",
+                    "message", "CSRF 토큰을 찾을 수 없습니다.",
+                    "details", Map.of()
+            ));
+        }
+
+        return ResponseEntity.ok(Map.of(
+                "headerName", csrfToken.getHeaderName(),
+                "token", csrfToken.getToken(),
+                "parameterName", csrfToken.getParameterName()
+        ));
     }
 }


### PR DESCRIPTION
- SecurityConfig를 임시로 전체 permitAll 설정으로 변경했습니다.
- Postman, Swagger, 프론트 테스트 편의를 위해 인증 없이 모든 API 접근 가능하도록 열어둔 상태입니다.
- 기능 개발 및 연동 테스트 완료 후, 다시 권한 설정을 단계적으로 적용할 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * CSRF 토큰을 조회할 수 있는 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 인증 및 토큰 관련 엔드포인트에서 예외 상황에 대해 일관된 JSON 에러 응답과 명확한 HTTP 상태 코드가 제공됩니다.
  * refresh_token 쿠키가 없을 경우, 명확한 에러 메시지와 함께 401 응답이 반환됩니다.

* **개선 사항**
  * 모든 인증 관련 응답이 표준화된 JSON 구조로 제공되어 클라이언트에서 처리하기 쉬워졌습니다.
  * 모든 요청에 대해 인증 없이 접근이 가능하도록 보안 설정이 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->