### PR TITLE
Fix: ErrorCode enum 마지막 세미콜론 오류 수정

### DIFF
--- a/src/main/java/com/codeit/sb01otbooteam06/global/exception/ErrorCode.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
   USER_NOT_FOUND("사용자를 찾을 수 없습니다."),
 
   //Profile
-  PROFILE_NOT_FOUND("프로필을 찾을 수 없슴니다.");
+  PROFILE_NOT_FOUND("프로필을 찾을 수 없슴니다."),
 
   //Feed
   FEED_NOT_FOUND("피드를 찾을 수 없습니다.");


### PR DESCRIPTION
`PROFILE_NOT_FOUND` 항목 뒤의 세미콜론을 콤마(,)로 수정했습니다.