### PR TITLE
feat(auth): 구글·카카오 OAuth 로그인 구현 및 JWT 연동 완료#120

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'software.amazon.awssdk:s3:2.25.13'
+    implementation 'software.amazon.awssdk:s3:2.25.27'
     // Monitoring
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.codeit.sb01otbooteam06.domain.auth.controller;
 
+import com.codeit.sb01otbooteam06.domain.auth.dto.OAuthUserResponse;
 import com.codeit.sb01otbooteam06.domain.auth.dto.ResetPasswordRequest;
 import com.codeit.sb01otbooteam06.domain.auth.dto.SignInRequest;
 import com.codeit.sb01otbooteam06.domain.auth.dto.TokenResponse;
+import com.codeit.sb01otbooteam06.domain.auth.oauth.OAuthService;
 import com.codeit.sb01otbooteam06.domain.auth.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -16,47 +18,37 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
-/**
- * 인증 관련 API 컨트롤러 (Swagger 명세 기준 완성본)
- */
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
+    private final OAuthService oAuthService;
 
-    /**
-     * 로그인 - accessToken 반환, refreshToken 쿠키에 저장
-     * 성공: 200 OK, accessToken 문자열 반환
-     * 실패: 401 Unauthorized, 예외 JSON 반환
-     */
     @PostMapping("/sign-in")
     public ResponseEntity<?> signIn(@RequestBody @Valid SignInRequest request,
                                     HttpServletResponse response) {
-
         try {
             TokenResponse tokenResponse = authService.signIn(request);
 
             ResponseCookie cookie = ResponseCookie.from("refresh_token", tokenResponse.getRefreshToken())
                     .httpOnly(true)
-                    .secure(false) // 배포 시 true로 변경 필요
+                    .secure(false)
                     .path("/")
-                    .maxAge(7 * 24 * 60 * 60) // 7일
+                    .maxAge(7 * 24 * 60 * 60)
                     .build();
 
             response.addHeader("Set-Cookie", cookie.toString());
             return ResponseEntity.ok(tokenResponse.getAccessToken());
 
         } catch (IllegalArgumentException e) {
-            // 비밀번호 불일치 등 실패 케이스
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "SignInFailedException",
                     "message", e.getMessage(),
                     "details", Map.of()
             ));
         } catch (Exception e) {
-            // 기타 예외 처리
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "SignInFailedException",
                     "message", "로그인에 실패했습니다.",
@@ -65,18 +57,11 @@ public class AuthController {
         }
     }
 
-    /**
-     * 비밀번호 초기화 (임시 비밀번호 발급)
-     * 성공: 204 No Content
-     * 실패: 404 Not Found, 예외 JSON 반환
-     */
     @PostMapping("/reset-password")
     public ResponseEntity<?> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
-
         try {
             authService.resetPassword(request);
             return ResponseEntity.noContent().build();
-
         } catch (com.codeit.sb01otbooteam06.domain.user.exception.UserNotFoundException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
                     "exceptionName", "UserNotFoundException",
@@ -86,15 +71,9 @@ public class AuthController {
         }
     }
 
-    /**
-     * 로그아웃 - refreshToken 쿠키 제거
-     * 성공: 204 No Content
-     * 실패: 401 Unauthorized, 예외 JSON 반환
-     */
     @PostMapping("/sign-out")
     public ResponseEntity<?> signOut(@CookieValue(value = "refresh_token", required = false) String refreshToken,
                                      HttpServletResponse response) {
-
         if (refreshToken == null || refreshToken.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "RefreshTokenMissingException",
@@ -103,7 +82,6 @@ public class AuthController {
             ));
         }
 
-        // 쿠키 제거
         ResponseCookie cookie = ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
                 .secure(false)
@@ -115,15 +93,8 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-
-    /**
-     * 토큰 재발급 - refreshToken으로 새로운 accessToken 발급
-     * 성공: 200 OK, accessToken 반환
-     * 실패: 401 Unauthorized, 예외 JSON 반환
-     */
     @PostMapping("/refresh")
     public ResponseEntity<?> refreshToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
-
         if (refreshToken == null || refreshToken.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "RefreshTokenMissingException",
@@ -135,7 +106,6 @@ public class AuthController {
         try {
             String newAccessToken = authService.refreshAccessToken(refreshToken);
             return ResponseEntity.ok(newAccessToken);
-
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "InvalidRefreshTokenException",
@@ -145,14 +115,8 @@ public class AuthController {
         }
     }
 
-    /**
-     * 엑세스 토큰 조회 - refreshToken으로 accessToken 반환
-     * 성공: 200 OK, accessToken 반환
-     * 실패: 401 Unauthorized, 예외 JSON 반환
-     */
     @GetMapping("/me")
     public ResponseEntity<?> getAccessToken(@CookieValue(value = "refresh_token", required = false) String refreshToken) {
-
         if (refreshToken == null || refreshToken.isEmpty()) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "RefreshTokenMissingException",
@@ -164,7 +128,6 @@ public class AuthController {
         try {
             String accessToken = authService.getAccessToken(refreshToken);
             return ResponseEntity.ok(accessToken);
-
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of(
                     "exceptionName", "InvalidRefreshTokenException",
@@ -173,11 +136,7 @@ public class AuthController {
             ));
         }
     }
-    /**
-     * CSRF 토큰 조회 API
-     * 성공: 200 OK, 토큰 정보 JSON 반환
-     * 실패: 401 Unauthorized, 예외 JSON 반환
-     */
+
     @GetMapping("/csrf-token")
     public ResponseEntity<?> getCsrfToken(HttpServletRequest request) {
         CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
@@ -195,5 +154,26 @@ public class AuthController {
                 "token", csrfToken.getToken(),
                 "parameterName", csrfToken.getParameterName()
         ));
+    }
+
+    @GetMapping("/oauth/callback/{provider}")
+    public ResponseEntity<?> oauthCallback(@PathVariable String provider,
+                                           @RequestParam String code) {
+        try {
+            OAuthUserResponse userResponse = oAuthService.getUserInfo(provider, code);
+            return ResponseEntity.ok(userResponse);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "exceptionName", "OAuthProviderException",
+                    "message", e.getMessage(),
+                    "details", Map.of()
+            ));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of(
+                    "exceptionName", "OAuthCallbackException",
+                    "message", "소셜 로그인 처리 중 오류가 발생했습니다.",
+                    "details", Map.of()
+            ));
+        }
     }
 }

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/OAuthController.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/controller/OAuthController.java
@@ -1,0 +1,61 @@
+package com.codeit.sb01otbooteam06.domain.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/oauth2/authorization")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    @Value("${oauth.google.client-id}")
+    private String googleClientId;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String googleRedirectUri;
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    @GetMapping("/{provider}")
+    public void redirectToProvider(@PathVariable String provider,
+                                   HttpServletResponse response) throws IOException {
+        String redirectUrl;
+
+        switch (provider.toLowerCase()) {
+            case "google":
+                redirectUrl = UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
+                        .queryParam("client_id", googleClientId)
+                        .queryParam("redirect_uri", googleRedirectUri)
+                        .queryParam("response_type", "code")
+                        .queryParam("scope", "email profile")
+                        .queryParam("access_type", "offline")
+                        .queryParam("prompt", "consent")
+                        .build()
+                        .toUriString();
+                break;
+
+            case "kakao":
+                redirectUrl = UriComponentsBuilder.fromUriString("https://kauth.kakao.com/oauth/authorize")
+                        .queryParam("client_id", kakaoClientId)
+                        .queryParam("redirect_uri", kakaoRedirectUri)
+                        .queryParam("response_type", "code")
+                        .build()
+                        .toUriString();
+                break;
+
+            default:
+                throw new IllegalArgumentException("지원하지 않는 provider: " + provider);
+        }
+
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/dto/OAuthUserResponse.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/dto/OAuthUserResponse.java
@@ -1,0 +1,11 @@
+package com.codeit.sb01otbooteam06.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/OAuthService.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/OAuthService.java
@@ -1,0 +1,7 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth;
+
+import com.codeit.sb01otbooteam06.domain.auth.dto.OAuthUserResponse;
+
+public interface OAuthService {
+    OAuthUserResponse getUserInfo(String provider, String code);
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/OAuthServiceImpl.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/OAuthServiceImpl.java
@@ -1,0 +1,56 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth;
+
+import com.codeit.sb01otbooteam06.domain.auth.dto.OAuthUserResponse;
+import com.codeit.sb01otbooteam06.domain.auth.jwt.JwtTokenProvider;
+import com.codeit.sb01otbooteam06.domain.auth.oauth.client.GoogleOAuthClient;
+import com.codeit.sb01otbooteam06.domain.auth.oauth.client.KakaoOAuthClient;
+import com.codeit.sb01otbooteam06.domain.auth.oauth.userinfo.*;
+import com.codeit.sb01otbooteam06.domain.user.entity.User;
+import com.codeit.sb01otbooteam06.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthServiceImpl implements OAuthService {
+
+    private final GoogleOAuthClient googleOAuthClient;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public OAuthUserResponse getUserInfo(String provider, String code) {
+        Map<String, Object> attributes;
+        OAuthUserInfo userInfo;
+
+        // provider에 따라 사용자 정보 요청
+        if (provider.equalsIgnoreCase("google")) {
+            attributes = googleOAuthClient.getUserInfo(code);
+            userInfo = new GoogleUserInfo(attributes);
+        } else if (provider.equalsIgnoreCase("kakao")) {
+            attributes = kakaoOAuthClient.getUserInfo(code);
+            userInfo = new KakaoUserInfo(attributes);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + provider);
+        }
+
+        // 이메일 기준으로 사용자 조회 또는 생성
+        User user = userRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() -> {
+                    User newUser = User.createSocialUser(userInfo.getEmail(), userInfo.getName());
+                    return userRepository.save(newUser);
+                });
+
+        // JWT 토큰 발급
+        UUID userId = user.getId();
+        String accessToken = jwtTokenProvider.generateAccessToken(userId);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+
+        // 응답 객체 반환
+        return new OAuthUserResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/client/GoogleOAuthClient.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/client/GoogleOAuthClient.java
@@ -1,0 +1,41 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth.client;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class GoogleOAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String clientId = "YOUR_GOOGLE_CLIENT_ID";
+    private final String clientSecret = "YOUR_GOOGLE_CLIENT_SECRET";
+    private final String redirectUri = "YOUR_GOOGLE_REDIRECT_URI";
+
+    public Map<String, Object> getUserInfo(String code) {
+        //토큰 요청
+        Map<String, String> tokenRequest = new HashMap<>();
+        tokenRequest.put("code", code);
+        tokenRequest.put("client_id", clientId);
+        tokenRequest.put("client_secret", clientSecret);
+        tokenRequest.put("redirect_uri", redirectUri);
+        tokenRequest.put("grant_type", "authorization_code");
+
+        Map<String, Object> tokenResponse = restTemplate.postForObject(
+                "https://oauth2.googleapis.com/token",
+                tokenRequest,
+                Map.class
+        );
+
+        String accessToken = (String) tokenResponse.get("access_token");
+
+        //사용자 정보 요청
+        String uri = UriComponentsBuilder.fromUriString("https://www.googleapis.com/oauth2/v2/userinfo")
+                .queryParam("access_token", accessToken)
+                .toUriString();
+
+        return restTemplate.getForObject(uri, Map.class);
+    }
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/client/KakaoOAuthClient.java
@@ -1,0 +1,50 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth.client;
+
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.util.*;
+
+@Component
+public class KakaoOAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final String clientId = "YOUR_KAKAO_CLIENT_ID";
+    private final String redirectUri = "YOUR_KAKAO_REDIRECT_URI";
+
+    public Map<String, Object> getUserInfo(String code) {
+        // 토큰 요청
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String body = "grant_type=authorization_code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&code=" + code;
+
+        HttpEntity<String> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> tokenResponse = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        String accessToken = (String) tokenResponse.getBody().get("access_token");
+
+        // 사용자 정보 요청
+        HttpHeaders authHeaders = new HttpHeaders();
+        authHeaders.setBearerAuth(accessToken);
+        HttpEntity<Void> userInfoRequest = new HttpEntity<>(authHeaders);
+
+        ResponseEntity<Map> userInfoResponse = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                userInfoRequest,
+                Map.class
+        );
+
+        return userInfoResponse.getBody();
+    }
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/GoogleUserInfo.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/GoogleUserInfo.java
@@ -1,0 +1,22 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth.userinfo;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuthUserInfo {
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+}
+

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/KakaoUserInfo.java
@@ -1,0 +1,31 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth.userinfo;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements OAuthUserInfo {
+    private final Map<String, Object> attributes;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+        if (email == null) {
+            // 이메일 없을 경우 닉네임으로
+            Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+            String nickname = (String) profile.get("nickname");
+            return nickname + "@kakao.com";
+        }
+        return email;
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return (String) profile.get("nickname");
+    }
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/OAuthUserInfo.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/auth/oauth/userinfo/OAuthUserInfo.java
@@ -1,0 +1,6 @@
+package com.codeit.sb01otbooteam06.domain.auth.oauth.userinfo;
+
+public interface OAuthUserInfo {
+    String getEmail();
+    String getName();
+}

--- a/src/main/java/com/codeit/sb01otbooteam06/domain/user/entity/User.java
+++ b/src/main/java/com/codeit/sb01otbooteam06/domain/user/entity/User.java
@@ -3,16 +3,16 @@ package com.codeit.sb01otbooteam06.domain.user.entity;
 import com.codeit.sb01otbooteam06.domain.base.BaseEntity;
 import com.codeit.sb01otbooteam06.domain.profile.entity.Profile;
 import jakarta.persistence.*;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Getter
@@ -97,24 +97,26 @@ public class User extends BaseEntity {
             now.isBefore(this.temporaryPasswordExpiration);
   }
 
-  // Oauth 부분 일단 주석 처리
+  /**
+   * 소셜 로그인 회원가입용 생성자 (정적 팩토리 메서드)
+   */
+  public static User createSocialUser(String email, String name) {
+    return User.builder()
+            .email(email)
+            .password("SOCIAL") // 소셜 로그인은 비밀번호 사용하지 않음
+            .name(name)
+            .role(Role.USER)
+            .locked(false)
+            .linkedOAuthProviders(new ArrayList<>(List.of("SOCIAL")))
+            .build();
+  }
 
-  /* //  소셜 로그인 연동 provider 추가
+  /**
+   * 소셜 로그인 연동 provider 추가
+   */
   public void addOAuthProvider(String provider) {
     if (!this.linkedOAuthProviders.contains(provider)) {
       this.linkedOAuthProviders.add(provider);
     }
-  }/*
-
-  /*소셜 로그인 회원가입용 생성자
-  public static User ofSocial(String email, String name, String provider) {
-    return User.builder()
-            .email(email)
-            .password("SOCIAL") // 실제 로그인은 패스워드 사용 안 함
-            .name(name)
-            .role(Role.USER)
-            .locked(false)
-            .linkedOAuthProviders(new ArrayList<>(List.of(provider)))
-            .build(); */
   }
-
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -32,13 +32,32 @@ kma:
   service-key: ${KMA_KEY}
 kakao:
   rest-key: ${KAKAO_KEY}
+
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+
+cloud:
+  aws:
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_S3_BUCKET_NAME}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000}
+
 logging:
   level:
     org:
       hibernate:
         sql: warn
         type.descriptor.sql: trace
-jwt:
-  secret: ${JWT_SECRET}
-  access-expiration: ${JWT_ACCESS_EXPIRATION:3600000}
-  refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000}


### PR DESCRIPTION
## #️⃣ Issue Number

#120 

## 📝 요약(Summary)

Google 및 Kakao OAuth2 소셜 로그인 기능을 구현
OAuth 인증 후 JWT Access/Refresh Token을 발급

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

테스트 코드 작성은 추후 PR로 분리 예정

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 구글 및 카카오 소셜 로그인을 지원하는 OAuth 인증 기능이 추가되었습니다.
  * OAuth 인증을 위한 전용 엔드포인트가 제공되며, 로그인 성공 시 액세스/리프레시 토큰이 발급됩니다.

* **버그 수정**
  * 해당 없음

* **문서화**
  * application-dev.yml에 OAuth 및 AWS S3 관련 환경설정 항목이 추가되었습니다.

* **리팩터링**
  * User 엔티티 내 소셜 로그인 관련 정적 팩토리 메서드 및 OAuth provider 추가 메서드가 정리 및 활성화되었습니다.

* **기타**
  * AWS S3 SDK 버전이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->