### PR TITLE
github actions에서 jq 경로 문제 수정

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -109,7 +109,7 @@ jobs:
         { "name": "RDS_URL", "value": "${{ secrets.RDS_URL }}" },
         { "name": "RDS_USERNAME", "value": "${{ secrets.RDS_USERNAME }}" },
         { "name": "RDS_PASSWORD", "value": "${{ secrets.RDS_PASSWORD }}" }
-        ]' obtoo-def-revision2.json > temp.json && mv temp.json obtoo-def-revision2.json
+        ]' .aws/obtoo-def-revision2.json > temp.json && mv temp.json .aws/obtoo-def-revision2.json
 
     - name: Deploy Amazon ECS task definition
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ECS 작업 정의 파일의 경로가 `.aws/obtoo-def-revision2.json`으로 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->