### PR TITLE
:rocket: ECS 서비스에 task 정의가 반영되지 않던 문제 수정

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -128,7 +128,7 @@ jobs:
         task_def_arn=$(aws ecs register-task-definition \
           --cli-input-json file://.aws/obtoo-def-revision2.json | \
           jq -r '.taskDefinition.taskDefinitionArn')
-        echo "task_def_arn=$task_def_arn" >> "$GITHUB_OUTPUT"
+        echo "::set-output name=task_def_arn::$task_def_arn"
 
     - name: Update ECS service to use new task definition
       run: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 워크플로우에서 ECS 태스크 정의의 출력 변수 설정 방식을 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->